### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ export default {
     UnpluginInjectPreload({
       files: [
         {
-          match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/
+          entryMatch: /Roboto-[a-zA-Z]*\.woff2$/,
+          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/
         },
         {
-          match: /lazy.[a-z-0-9]*.(css|js)$/,
+          outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
         }
       ]
     })
@@ -105,7 +106,10 @@ export default {
 ### Options
 
 * files: An array of files object
-  * match: A regular expression to target build files you want to preload
+  * entryMatch: A regular expression to target entry files you want to preload
+  * outputMatch: A regular expression to target output build files you want to preload
+  > You need to set at least `entryMatch` or/and `outputMatch`. Be aware that entry file is not always present for webpack and `entryMatch` will do nothing.
+
   * attributes (optional):
   If this option is ommited, it will determine the `mime` and the `as` attributes automatically.
   You can also add/override any attributes you want.
@@ -122,7 +126,7 @@ export default {
     UnpluginInjectPreload({
       files: [
         {
-          match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
           attributes: {
             'type': 'font/woff2',
             'as': 'font',
@@ -131,7 +135,7 @@ export default {
           }
         },
         {
-          match: /lazy.[a-z-0-9]*.(js)$/,
+          outputMatch: /lazy.[a-z-0-9]*.(js)$/,
           attributes: {
             rel: 'modulepreload',
             type: undefined,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version](https://img.shields.io/npm/v/unplugin-inject-preload?color=a1b858&label=)](https://www.npmjs.com/package/unplugin-inject-preload) [![node-current](https://img.shields.io/node/v/unplugin-inject-preload)](https://nodejs.org/) [![Coverage Status](https://coveralls.io/repos/github/Applelo/unplugin-inject-preload/badge.svg?branch=main)](https://coveralls.io/github/Applelo/unplugin-inject-preload?branch=main)
 
-This plugin adds preload links by getting output assets from the build tools your using.
+This plugin adds preload links by getting output assets from the build tools you are using.
 
 Supporting:
 - Vite 3 and 4 (on build only)
@@ -92,7 +92,6 @@ export default {
       files: [
         {
           entryMatch: /Roboto-[a-zA-Z]*\.woff2$/,
-          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/
         },
         {
           outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
@@ -126,6 +125,7 @@ export default {
     UnpluginInjectPreload({
       files: [
         {
+          entryMatch: /Roboto-[a-zA-Z]*\.woff2$/,
           outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
           attributes: {
             'type': 'font/woff2',

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ export default {
       files: [
         {
 -         match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
-+          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
++         outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
           attributes: {
             'type': 'font/woff2',
             'as': 'font',
@@ -219,6 +219,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin(),
 -   new HtmlWebpackInjectPreload({
++   UnpluginInjectPreload({
       files: [
         {
 -         match: /.*\.woff2$/,

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Supporting:
 
 > This plugin combines [vite-plugin-inject-preload](https://github.com/Applelo/vite-plugin-inject-preload) and [html-webpack-inject-preload](https://github.com/principalstudio/html-webpack-inject-preload) into one package.
 
+> See the [migration guide](#migrate) for `vite-plugin-inject-preload` and `html-webpack-inject-preload` .
+
 ## Install
 
 ```bash
@@ -143,6 +145,90 @@ export default {
         }
       ],
       injectTo: 'head-prepend'
+    })
+  ]
+}
+```
+
+## Migration
+
+### From vite-plugin-inject-preload
+
+`package.json`
+
+```diff
+{
+  "devDependencies": {
+-   "vite-plugin-inject-preload": "*",
++   "unplugin-inject-preload": "^1.1.0",
+  }
+}
+```
+
+`vite.config.js`
+
+```diff
+- import VitePluginInjectPreload from 'vite-plugin-inject-preload'
++ import UnpluginInjectPreload from 'unplugin-inject-preload/vite'
+
+export default {
+  plugins: [
+    VitePluginInjectPreload({
+      files: [
+        {
+-         match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
++          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+          attributes: {
+            'type': 'font/woff2',
+            'as': 'font',
+            'crossorigin': 'anonymous',
+            'data-font': 'Roboto'
+          }
+        },
+      ],
+      injectTo: 'head-prepend'
+    })
+  ]
+}
+```
+
+### From html-webpack-inject-preload
+
+`package.json`
+
+```diff
+{
+  "devDependencies": {
+-   "@principalstudio/html-webpack-inject-preload": "*",
++   "unplugin-inject-preload": "^1.1.0",
+  }
+}
+```
+
+```diff
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+- const HtmlWebpackInjectPreload = require('@principalstudio/html-webpack-inject-preload');
++ const UnpluginInjectPreload = require('unplugin-inject-preload/webpack');
+
+module.exports = {
+  entry: 'index.js',
+  output: {
+    path: __dirname + '/dist',
+    filename: 'index_bundle.js'
+  },
+  plugins: [
+    new HtmlWebpackPlugin(),
+-   new HtmlWebpackInjectPreload({
+      files: [
+        {
+-         match: /.*\.woff2$/,
++         outputMatch: /.*\.woff2$/,
+          attributes: {
+            as: 'font',
+            type: 'font/woff2', crossorigin: true
+          },
+        },
+      ]
     })
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unplugin-inject-preload",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packageManager": "pnpm@8.7.0",
   "description": "Inject <link rel='preload'> for Webpack/ViteJS",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^0.41.0",
     "@types/mime-types": "^2.1.1",
-    "@types/node": "^20.5.6",
+    "@types/node": "^20.5.7",
     "@vitest/coverage-v8": "^0.34.3",
     "css-loader": "^6.8.1",
     "esno": "^0.17.0",
@@ -99,7 +99,7 @@
     "ts-loader": "^9.4.4",
     "tsup": "^7.2.0",
     "tsx": "^3.12.7",
-    "typescript": "^5.1.6",
+    "typescript": "^5.2.2",
     "vite": "^4.4.9",
     "vitest": "^0.34.3",
     "webpack": "^5.88.2"

--- a/playground/vitejs/vite.config.ts
+++ b/playground/vitejs/vite.config.ts
@@ -18,10 +18,10 @@ export default defineConfig({
     UnpluginInjectPreload({
       files: [
         {
-          match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+          outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
         },
         {
-          match: /lazy.[a-z-0-9]*.(css|js)$/,
+          outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
         },
       ],
       injectTo: 'custom',

--- a/playground/webpack/webpack.config.js
+++ b/playground/webpack/webpack.config.js
@@ -57,10 +57,10 @@ module.exports = {
       injectTo: 'custom',
       files: [
         {
-          match: /Roboto-[a-zA-Z]*.[a-z-0-9]*\.woff2$/,
+          outputmatch: /Roboto-[a-zA-Z]*.[a-z-0-9]*\.woff2$/,
         },
         {
-          match: /^(?!main).*\.(css|js)$/,
+          outputMatch: /^(?!main).*\.(css|js)$/,
         },
       ],
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^0.41.0
-        version: 0.41.0(eslint@8.47.0)(typescript@5.1.6)
+        version: 0.41.0(eslint@8.47.0)(typescript@5.2.2)
       '@types/mime-types':
         specifier: ^2.1.1
         version: 2.1.1
       '@types/node':
-        specifier: ^20.5.6
-        version: 20.5.6
+        specifier: ^20.5.7
+        version: 20.5.7
       '@vitest/coverage-v8':
         specifier: ^0.34.3
         version: 0.34.3(vitest@0.34.3)
@@ -44,19 +44,19 @@ importers:
         version: 2.7.6(webpack@5.88.2)
       ts-loader:
         specifier: ^9.4.4
-        version: 9.4.4(typescript@5.1.6)(webpack@5.88.2)
+        version: 9.4.4(typescript@5.2.2)(webpack@5.88.2)
       tsup:
         specifier: ^7.2.0
-        version: 7.2.0(postcss@8.4.28)(typescript@5.1.6)
+        version: 7.2.0(postcss@8.4.28)(typescript@5.2.2)
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
       typescript:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.6)
+        version: 4.4.9(@types/node@20.5.7)
       vitest:
         specifier: ^0.34.3
         version: 0.34.3
@@ -74,7 +74,7 @@ importers:
         version: link:../..
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@20.5.6)
+        version: 4.4.9(@types/node@20.5.7)
       vite-plugin-inspect:
         specifier: ^0.7.38
         version: 0.7.38(vite@4.4.9)
@@ -121,13 +121,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
-  /@antfu/eslint-config-basic@0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6):
+  /@antfu/eslint-config-basic@0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-zcwFv+nEV/NroeeVWriNdnIGd9soOLRG8wIiVz4VVJ0BjONrqQR56HLG/gDxH/1GUYBnQCEcVxGUmegce08cnw==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
       eslint: 8.47.0
-      eslint-plugin-antfu: 0.41.0(eslint@8.47.0)(typescript@5.1.6)
+      eslint-plugin-antfu: 0.41.0(eslint@8.47.0)(typescript@5.2.2)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.47.0)
       eslint-plugin-html: 7.1.0
       eslint-plugin-import: /eslint-plugin-i@2.28.0-2(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)
@@ -150,18 +150,18 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config-ts@0.41.0(eslint@8.47.0)(typescript@5.1.6):
+  /@antfu/eslint-config-ts@0.41.0(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-ng3GYpJGZgrxGwBVda/MgUpveH3LbEqdPCFi1+S5e62W4kf8rmEVbhc0I8w7/aKN0uNqir5SInYg8gob2maDAQ==}
     peerDependencies:
       eslint: '>=7.4.0'
       typescript: '>=3.9'
     dependencies:
-      '@antfu/eslint-config-basic': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@antfu/eslint-config-basic': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      typescript: 5.1.6
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -169,13 +169,13 @@ packages:
       - supports-color
     dev: true
 
-  /@antfu/eslint-config-vue@0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6):
+  /@antfu/eslint-config-vue@0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-iJiEGRUgRmT3mQCmGl0hTMwq/ShXRjRPjpgsDcphKJyEF06ZIR/4gxHn+utQRLT2hD39DQN8gk0ZbpV3gWtf/g==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-basic': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@antfu/eslint-config-ts': 0.41.0(eslint@8.47.0)(typescript@5.1.6)
+      '@antfu/eslint-config-basic': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@antfu/eslint-config-ts': 0.41.0(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
       eslint-plugin-vue: 9.17.0(eslint@8.47.0)
       local-pkg: 0.4.3
@@ -189,14 +189,14 @@ packages:
       - typescript
     dev: true
 
-  /@antfu/eslint-config@0.41.0(eslint@8.47.0)(typescript@5.1.6):
+  /@antfu/eslint-config@0.41.0(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-510DginDPdzf45O6HOah3cK6NHXxobBc43IdBQCQmUGb+av9LIJjrd1idThFoyFh6m05iZ4YX/mhnhhJFqLiNw==}
     peerDependencies:
       eslint: '>=7.4.0'
     dependencies:
-      '@antfu/eslint-config-vue': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@antfu/eslint-config-vue': 0.41.0(@typescript-eslint/eslint-plugin@6.4.1)(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.47.0)
       eslint-plugin-html: 7.1.0
@@ -868,8 +868,8 @@ packages:
     resolution: {integrity: sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==}
     dev: true
 
-  /@types/node@20.5.6:
-    resolution: {integrity: sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==}
+  /@types/node@20.5.7:
+    resolution: {integrity: sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==}
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -884,7 +884,7 @@ packages:
     resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6):
+  /@typescript-eslint/eslint-plugin@6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -896,10 +896,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.8.0
-      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 6.4.1
-      '@typescript-eslint/type-utils': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/type-utils': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.4.1
       debug: 4.3.4
       eslint: 8.47.0
@@ -907,13 +907,13 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.4.1(eslint@8.47.0)(typescript@5.1.6):
+  /@typescript-eslint/parser@6.4.1(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -925,11 +925,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.4.1
       '@typescript-eslint/types': 6.4.1
-      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.4.1
       debug: 4.3.4
       eslint: 8.47.0
-      typescript: 5.1.6
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -950,7 +950,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.4.1
     dev: true
 
-  /@typescript-eslint/type-utils@6.4.1(eslint@8.47.0)(typescript@5.1.6):
+  /@typescript-eslint/type-utils@6.4.1(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -960,12 +960,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.1.6)
-      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.47.0
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -980,7 +980,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.2.2):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -995,13 +995,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.1.6)
-      typescript: 5.1.6
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.4.1(typescript@5.1.6):
+  /@typescript-eslint/typescript-estree@6.4.1(typescript@5.2.2):
     resolution: {integrity: sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1016,13 +1016,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.2(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.47.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@5.62.0(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1033,7 +1033,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.2.2)
       eslint: 8.47.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -1042,7 +1042,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.4.1(eslint@8.47.0)(typescript@5.1.6):
+  /@typescript-eslint/utils@6.4.1(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1053,7 +1053,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 6.4.1
       '@typescript-eslint/types': 6.4.1
-      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.1.6)
+      '@typescript-eslint/typescript-estree': 6.4.1(typescript@5.2.2)
       eslint: 8.47.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -1993,7 +1993,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/parser': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
       debug: 3.2.7
       eslint: 8.47.0
       eslint-import-resolver-node: 0.3.9
@@ -2001,10 +2001,10 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-antfu@0.41.0(eslint@8.47.0)(typescript@5.1.6):
+  /eslint-plugin-antfu@0.41.0(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-JeEeDZgz7oqYPYWYNQHdXrKaW2nhJz/70jeMZUkaNjVp72cpsJPH3idiEhIhGu3wjFdsOMCoEkboT/DQXlCaqA==}
     dependencies:
-      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 6.4.1(eslint@8.47.0)(typescript@5.2.2)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2062,7 +2062,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.47.0)(typescript@5.1.6):
+  /eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@6.4.1)(eslint@8.47.0)(typescript@5.2.2):
     resolution: {integrity: sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -2075,8 +2075,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
     transitivePeerDependencies:
       - supports-color
@@ -2172,7 +2172,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.1.6)
+      '@typescript-eslint/eslint-plugin': 6.4.1(@typescript-eslint/parser@6.4.1)(eslint@8.47.0)(typescript@5.2.2)
       eslint: 8.47.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -2840,7 +2840,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.5.6
+      '@types/node': 20.5.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -3942,32 +3942,17 @@ packages:
     hasBin: true
     dev: true
 
-  /ts-api-utils@1.0.2(typescript@5.1.6):
+  /ts-api-utils@1.0.2(typescript@5.2.2):
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.2.2
     dev: true
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-    dev: true
-
-  /ts-loader@9.4.4(typescript@5.1.6)(webpack@5.88.2):
-    resolution: {integrity: sha512-MLukxDHBl8OJ5Dk3y69IsKVFRA/6MwzEqBgh+OXMPB/OD01KQuWPFd1WAQP8a5PeSCAxfnkhiuWqfmFJzJQt9w==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      typescript: '*'
-      webpack: ^5.0.0
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 5.15.0
-      micromatch: 4.0.5
-      semver: 7.5.4
-      typescript: 5.1.6
-      webpack: 5.88.2(esbuild@0.18.20)(webpack-cli@5.1.4)
     dev: true
 
   /ts-loader@9.4.4(typescript@5.2.2)(webpack@5.88.2):
@@ -3993,7 +3978,7 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsup@7.2.0(postcss@8.4.28)(typescript@5.1.6):
+  /tsup@7.2.0(postcss@8.4.28)(typescript@5.2.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -4024,20 +4009,20 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.1.6
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils@3.21.0(typescript@5.1.6):
+  /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.1.6
+      typescript: 5.2.2
     dev: true
 
   /tsx@3.12.7:
@@ -4076,12 +4061,6 @@ packages:
   /type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
-    dev: true
-
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
     dev: true
 
   /typescript@5.2.2:
@@ -4160,7 +4139,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.34.3(@types/node@20.5.6):
+  /vite-node@0.34.3(@types/node@20.5.7):
     resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -4170,7 +4149,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.5.6)
+      vite: 4.4.9(@types/node@20.5.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4200,13 +4179,13 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.4.9(@types/node@20.5.6)
+      vite: 4.4.9(@types/node@20.5.7)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /vite@4.4.9(@types/node@20.5.6):
+  /vite@4.4.9(@types/node@20.5.7):
     resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -4234,7 +4213,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.5.6
+      '@types/node': 20.5.7
       esbuild: 0.18.20
       postcss: 8.4.28
       rollup: 3.28.1
@@ -4275,7 +4254,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 20.5.6
+      '@types/node': 20.5.7
       '@vitest/expect': 0.34.3
       '@vitest/runner': 0.34.3
       '@vitest/snapshot': 0.34.3
@@ -4294,8 +4273,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@20.5.6)
-      vite-node: 0.34.3(@types/node@20.5.6)
+      vite: 4.4.9(@types/node@20.5.7)
+      vite-node: 0.34.3(@types/node@20.5.7)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/helper/getTagsAttributes.ts
+++ b/src/helper/getTagsAttributes.ts
@@ -27,7 +27,7 @@ export function getTagsAttributes(
         continue
 
       const attrs: HtmlTagDescriptor['attrs'] = file.attributes || {}
-      const href = `${basePath}${asset}`
+      const href = `${basePath}${asset.output}`
       const type = attrs.type ? attrs.type : mimeLookup(asset.output)
       const as
         = typeof type === 'string' ? getAsWithMime(type) : undefined

--- a/src/helper/getTagsAttributes.ts
+++ b/src/helper/getTagsAttributes.ts
@@ -1,9 +1,14 @@
 import type { HtmlTagDescriptor } from 'vite'
 import { lookup as mimeLookup } from 'mime-types'
-import type { Options } from '../types'
+import type { AssetsSet, Options } from '../types'
 import { getAsWithMime } from './getAsWithMime'
 
-export function getTagsAttributes(assetsSet: Set<string>, options: Options, basePath = '') {
+export function getTagsAttributes(
+  assetsSet: AssetsSet,
+  options: Options,
+  basePath = '',
+  warn = console.warn,
+) {
   const tagsAttributes = []
   const assets = Array.from(assetsSet)
 
@@ -12,12 +17,18 @@ export function getTagsAttributes(assetsSet: Set<string>, options: Options, base
 
     for (let index = 0; index < options.files.length; index++) {
       const file = options.files[index]
-      if (!file.match.test(asset))
+      if (!(file.entryMatch || file.outputMatch)) {
+        warn('[unplugin-inject-preload] You should have at least one option between entryMatch and outputMatch.')
+        continue
+      }
+      if (file.outputMatch && !file.outputMatch.test(asset.output))
+        continue
+      if (file.entryMatch && !file.entryMatch.test(asset.entry))
         continue
 
       const attrs: HtmlTagDescriptor['attrs'] = file.attributes || {}
       const href = `${basePath}${asset}`
-      const type = attrs.type ? attrs.type : mimeLookup(asset)
+      const type = attrs.type ? attrs.type : mimeLookup(asset.output)
       const as
         = typeof type === 'string' ? getAsWithMime(type) : undefined
 

--- a/src/helper/getTagsAttributes.ts
+++ b/src/helper/getTagsAttributes.ts
@@ -1,13 +1,13 @@
 import type { HtmlTagDescriptor } from 'vite'
 import { lookup as mimeLookup } from 'mime-types'
-import type { AssetsSet, Options } from '../types'
+import type { AssetsSet, Options, UnpluginLogger } from '../types'
 import { getAsWithMime } from './getAsWithMime'
 
 export function getTagsAttributes(
   assetsSet: AssetsSet,
   options: Options,
-  basePath = '',
-  warn = console.warn,
+  basePath: string,
+  log: UnpluginLogger,
 ) {
   const tagsAttributes = []
   const assets = Array.from(assetsSet)
@@ -18,7 +18,7 @@ export function getTagsAttributes(
     for (let index = 0; index < options.files.length; index++) {
       const file = options.files[index]
       if (!(file.entryMatch || file.outputMatch)) {
-        warn('[unplugin-inject-preload] You should have at least one option between entryMatch and outputMatch.')
+        log.warn('[unplugin-inject-preload] You should have at least one option between entryMatch and outputMatch.')
         continue
       }
       if (file.outputMatch && !file.outputMatch.test(asset.output))

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export const unpluginFactory: UnpluginFactory<Options> = options => ({
       hooks.alterAssetTagGroups.tapAsync(
         name,
         (data, cb) => {
-          const outputs = Object.keys(compilation.assetsInfo).sort()
+          const outputs = Array.from(compilation.assetsInfo.keys()).sort()
           const assets: AssetsSet = new Set()
           outputs.forEach((output) => {
             const entry = compilation.assetsInfo.get(output)?.sourceFilename || ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import type { HtmlTagDescriptor } from 'vite'
+import type { HtmlTagDescriptor, Logger } from 'vite'
+import type { Compilation } from 'webpack'
 
 export interface OptionsFiles {
   /**
@@ -27,3 +28,4 @@ export interface Options {
 }
 
 export type AssetsSet = Set<{ entry: string; output: string }>
+export type UnpluginLogger = Logger | Compilation['logger']

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,13 @@ import type { HtmlTagDescriptor } from 'vite'
 
 export interface OptionsFiles {
   /**
+   * Regular expression to target entry files
+   */
+  entryMatch?: RegExp
+  /**
    * Regular expression to target build files
    */
-  match: RegExp
+  outputMatch?: RegExp
   /**
    * Attributes added to the preload links
    */
@@ -21,3 +25,5 @@ export interface Options {
    */
   injectTo?: 'head' | 'head-prepend' | 'custom'
 }
+
+export type AssetsSet = Set<{ entry: string; output: string }>

--- a/test/__snapshots__/vite.test.ts.snap
+++ b/test/__snapshots__/vite.test.ts.snap
@@ -134,6 +134,46 @@ exports[`excerpt vitejs > test customPosition with basePath 1`] = `
 </html>"
 `;
 
+exports[`excerpt vitejs > test entryMatch 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Unplugin Inject Preload</title>
+    <!--__unplugin-inject-preload__-->
+    <script type=\\"module\\" crossorigin src=\\"/assets/index-250563bc.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/assets/index-6e93ae19.css\\">
+    <link rel=\\"preload\\" href=\\"/assets/Roboto-Italic-7d6fc55f.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+    <link rel=\\"preload\\" href=\\"/assets/Roboto-Regular-a9876de8.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>"
+`;
+
+exports[`excerpt vitejs > test entryMatch with basePath 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Unplugin Inject Preload</title>
+    <!--__unplugin-inject-preload__-->
+    <script type=\\"module\\" crossorigin src=\\"/base/assets/index-01788e7d.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/base/assets/index-30f5c21d.css\\">
+    <link rel=\\"preload\\" href=\\"/base/assets/Roboto-Italic-7d6fc55f.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+    <link rel=\\"preload\\" href=\\"/base/assets/Roboto-Regular-a9876de8.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>"
+`;
+
 exports[`excerpt vitejs > test injectBottom 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">

--- a/test/__snapshots__/vite.test.ts.snap
+++ b/test/__snapshots__/vite.test.ts.snap
@@ -258,6 +258,42 @@ exports[`excerpt vitejs > test modulepreload with basePath 1`] = `
 </html>"
 `;
 
+exports[`excerpt vitejs > test noMatch 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Unplugin Inject Preload</title>
+    <!--__unplugin-inject-preload__-->
+    <script type=\\"module\\" crossorigin src=\\"/assets/index-250563bc.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/assets/index-6e93ae19.css\\">
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>"
+`;
+
+exports[`excerpt vitejs > test noMatch with basePath 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Unplugin Inject Preload</title>
+    <!--__unplugin-inject-preload__-->
+    <script type=\\"module\\" crossorigin src=\\"/base/assets/index-01788e7d.js\\"></script>
+    <link rel=\\"stylesheet\\" href=\\"/base/assets/index-30f5c21d.css\\">
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>"
+`;
+
 exports[`excerpt vitejs > test noType 1`] = `
 "<!DOCTYPE html>
 <html lang=\\"en\\">

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -114,6 +114,42 @@ exports[`excerpt webpack > test customPosition with basePath 1`] = `
 "
 `;
 
+exports[`excerpt webpack > test entryMatch 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\"/>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Webpack App</title>
+    <script defer src=\\"/main.js\\"></script><link href=\\"/main.css\\" rel=\\"stylesheet\\"><link rel=\\"preload\\" href=\\"/Roboto-Italic-96e486355f319e0b182b.woff2\\" type=\\"font/woff2\\" as=\\"font\\"><link rel=\\"preload\\" href=\\"/Roboto-Regular-ec5068bd8823a38af494.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+    <!--__unplugin-inject-preload__-->
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>
+"
+`;
+
+exports[`excerpt webpack > test entryMatch with basePath 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\"/>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Webpack App</title>
+    <script defer src=\\"/base/main.js\\"></script><link href=\\"/base/main.css\\" rel=\\"stylesheet\\"><link rel=\\"preload\\" href=\\"/base/Roboto-Italic-96e486355f319e0b182b.woff2\\" type=\\"font/woff2\\" as=\\"font\\"><link rel=\\"preload\\" href=\\"/base/Roboto-Regular-ec5068bd8823a38af494.woff2\\" type=\\"font/woff2\\" as=\\"font\\">
+    <!--__unplugin-inject-preload__-->
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>
+"
+`;
+
 exports[`excerpt webpack > test injectBottom 1`] = `
 "<!DOCTYPE html>
 <html>

--- a/test/__snapshots__/webpack.test.ts.snap
+++ b/test/__snapshots__/webpack.test.ts.snap
@@ -222,6 +222,42 @@ exports[`excerpt webpack > test modulepreload with basePath 1`] = `
 "
 `;
 
+exports[`excerpt webpack > test noMatch 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\"/>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Webpack App</title>
+    <script defer src=\\"/main.js\\"></script><link href=\\"/main.css\\" rel=\\"stylesheet\\">
+    <!--__unplugin-inject-preload__-->
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>
+"
+`;
+
+exports[`excerpt webpack > test noMatch with basePath 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"utf-8\\"/>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\" />
+    <title>Webpack App</title>
+    <script defer src=\\"/base/main.js\\"></script><link href=\\"/base/main.css\\" rel=\\"stylesheet\\">
+    <!--__unplugin-inject-preload__-->
+  </head>
+  <body>
+    <h1>Unplugin Inject Preload</h1>
+    
+  </body>
+</html>
+"
+`;
+
 exports[`excerpt webpack > test noType 1`] = `
 "<!DOCTYPE html>
 <html>

--- a/test/fixtures/configs.ts
+++ b/test/fixtures/configs.ts
@@ -87,4 +87,13 @@ export default {
     ],
     injectTo: 'head',
   },
+  noMatch: {
+    files: [
+      {
+        attributes: {
+          rel: 'modulepreload',
+        },
+      },
+    ],
+  },
 } satisfies Record<string, Options>

--- a/test/fixtures/configs.ts
+++ b/test/fixtures/configs.ts
@@ -4,10 +4,10 @@ export default {
   injectBottom: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
       },
       {
-        match: /lazy.[a-z-0-9]*.(css|js)$/,
+        outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
       },
     ],
     injectTo: 'head',
@@ -15,7 +15,7 @@ export default {
   customAttributes: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
         attributes: {
           'as': 'font',
           'crossorigin': 'anonymous',
@@ -28,23 +28,23 @@ export default {
   auto: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
       },
       {
-        match: /lazy.[a-z-0-9]*.(css|js)$/,
+        outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
       },
     ],
   },
   customPosition: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
         attributes: {
           'data-vite-plugin-inject-preload': true,
         },
       },
       {
-        match: /lazy.[a-z-0-9]*.(css|js)$/,
+        outputMatch: /lazy.[a-z-0-9]*.(css|js)$/,
       },
     ],
     injectTo: 'custom',
@@ -52,7 +52,7 @@ export default {
   wrongAttributes: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
         attributes: {
           href: './yolo.woff2',
         },
@@ -62,7 +62,7 @@ export default {
   noType: {
     files: [
       {
-        match: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
+        outputMatch: /Roboto-[a-zA-Z]*-[a-z-0-9]*\.woff2$/,
         attributes: {
           type: undefined,
         },
@@ -72,7 +72,7 @@ export default {
   modulepreload: {
     files: [
       {
-        match: /lazy.[a-z-0-9]*.(js)$/,
+        outputMatch: /lazy.[a-z-0-9]*.(js)$/,
         attributes: {
           rel: 'modulepreload',
         },

--- a/test/fixtures/configs.ts
+++ b/test/fixtures/configs.ts
@@ -79,4 +79,12 @@ export default {
       },
     ],
   },
+  entryMatch: {
+    files: [
+      {
+        entryMatch: /Roboto-[a-zA-Z]*\.woff2$/,
+      },
+    ],
+    injectTo: 'head',
+  },
 } satisfies Record<string, Options>

--- a/test/getHTMLWebpackPlugin.test.ts
+++ b/test/getHTMLWebpackPlugin.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { getHTMLWebpackPlugin } from '../src/helper/getHTMLWebpackPlugin'
 
 describe('excerpt get HTMLWebpackPlugin', () => {
   it('get HTMLWebpackPlugin', async () => {
     const HTMLWebpackPlugin = await getHTMLWebpackPlugin()
     expect(HTMLWebpackPlugin).not.toBeNull()
+  })
+
+  it('failed get HTMLWebpackPlugin', async () => {
+    vi.doMock('html-webpack-plugin', () => {})
+    try {
+      await getHTMLWebpackPlugin()
+    }
+    catch (error) {
+      expect(error).toBeDefined()
+    }
   })
 })

--- a/test/getHTMLWebpackPlugin.test.ts
+++ b/test/getHTMLWebpackPlugin.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { getHTMLWebpackPlugin } from '../src/helper/getHTMLWebpackPlugin'
+
+describe('excerpt get HTMLWebpackPlugin', () => {
+  it('get HTMLWebpackPlugin', async () => {
+    const HTMLWebpackPlugin = await getHTMLWebpackPlugin()
+    expect(HTMLWebpackPlugin).not.toBeNull()
+  })
+})

--- a/test/webpack.test.ts
+++ b/test/webpack.test.ts
@@ -82,12 +82,12 @@ describe('excerpt webpack', () => {
       it(`test ${key}`, async () => {
         const output = await buildWebpack(config)
         expect(output).toMatchSnapshot()
-      })
+      }, 8000)
 
       it(`test ${key} with basePath`, async () => {
         const output = await buildWebpack(config, { output: { publicPath: '/base' } })
         expect(output).toMatchSnapshot()
-      })
+      }, 8000)
     }
   }
 })


### PR DESCRIPTION
- Add `entryMatch` and rename `match` in `outputMatch`
- Add migration guide for vite-plugin-inject-preload and html-webpack-inject-preload